### PR TITLE
Fixed volume data structure

### DIFF
--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -952,7 +952,7 @@ __global__ void generate_next_nerf_network_inputs(
 		// -----------UPDATE------------
 
 		float dt = calc_dt(t, cone_angle);
-		network_input(i + j * n_elements)->set_with_optional_extra_dims(warp_position(origin + dir * t, train_aabb), warp_direction(dir), warp_dt(dt), extra_dims, network_input.stride_in_bytes); // XXXCONE
+		network_input(i + j * n_elements)->set_with_optional_extra_dims(warp_position(pos, train_aabb), warp_direction(dir), warp_dt(dt), extra_dims, network_input.stride_in_bytes); // XXXCONE
 		t += dt;
 	}
 


### PR DESCRIPTION
**Modified :**
- Fixed basic structure for volume rendering

**NOTE :**
- 볼륨 데이터에서 가져온 데이터가 ray marching함수에만 적용되고, NeRF 좌표  `network_input`에 적용되지 않은 오류 수정