### PR TITLE
Update volume deformation structure

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -556,12 +556,12 @@ public:
 
 	bool m_init_volume = false;
 	bool m_update_volume = false;
-	vec3 m_input_pos = vec3(0.0f);
-	vec3 m_input_dir = vec3(0.0f);
-
 	bool m_reset_volume = false;
 	bool m_undo_deform = false;
 	bool m_redo_deform = false;
+
+	vec3 m_input_pos = vec3(0.0f);
+	vec3 m_input_dir = vec3(0.0f);
 	int  m_deform_range = 5;
 	float m_deform_force = 0.8f;
 


### PR DESCRIPTION
**Added :**
- Structure `DeformInfo` which holds all data used in deformation

**Modified :**
- Fixed all codes related to `undo` and `redo` functions to use stack `DeformInfo`

**NOTE :**
> 현재 `undo`함수가 정상적으로 실행되지 않은 원인을 찾은 상태로, 내일 중으로 해결하여 PR 올릴 예정.<br>
변형되는 deform영역을 다양한 형태로 지정할 수 있는 방법도 고려 바람.