### PR TITLE
Fixed undo, redo and reset deformations

### DIFF
--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -794,9 +794,9 @@ void Testbed::imgui() {
 
 	if (!m_training_data_available) { ImGui::BeginDisabled(); }
 
-	if (ImGui::CollapsingHeader("Edit Volume data", !m_train ? ImGuiTreeNodeFlags_DefaultOpen : 0)) {
-		if (imgui_colored_button("Reset Volume_data", 0.f)) {
-			m_init_volume = false;
+	if (ImGui::CollapsingHeader("Edit Volume Data", !m_train ? ImGuiTreeNodeFlags_DefaultOpen : 0)) {
+		if (imgui_colored_button("Reset Volume Data", 0.f)) {
+			m_reset_volume = true;
 			reset_accumulation();
 		}
 
@@ -812,9 +812,9 @@ void Testbed::imgui() {
 		}
 
 		ImGui::SetNextItemWidth(120);
-		ImGui::SliderInt("deform range", &m_deform_range, 1, 5);
+		ImGui::SliderInt("Deform range", &m_deform_range, 1, 5);
 		ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.3f);
-		ImGui::SliderFloat("deform weight", &m_deform_force, 0.01f, 1.0f, "%.01f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
+		ImGui::SliderFloat("Deform force", &m_deform_force, 0.01f, 1.0f, "%.01f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
 		ImGui::PopItemWidth();
 	}
 


### PR DESCRIPTION
**Added :**
- Structure `DeformArea` to add index data of active deformation voxel
- Function `reset_volume` to encapsule all codes related to resetting volume data

**Modifications :**
- Fixed undo and redo function 
- Fixed `m_init_volume = false` to `m_reset_volume = true` when pressing `Reset Volume Data` in the GUI
- Fixed undo stack and redo stack not being cleared after volume data has reset

**NOTE :**
> 변형 후 좌표값을 가지고 undo를 진행할 때 인덱스 값을 가져와 `distance`를 구하게 된 상황으로, 해당 voxel이 가지는 각 축의 인덱스 정보를 `DeformArea` 구조체에 저장하여 사용할 수 있는 환경을 구축

